### PR TITLE
bump versions & fix dupe detections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directories: ["/", "/identify"] # Location of package manifests
+    directories: ["/"] # Location of package manifests
     schedule:
       interval: "weekly"

--- a/identify/requirements.txt
+++ b/identify/requirements.txt
@@ -25,7 +25,7 @@ opt_einsum==3.4.0
 optree==0.15.0
 packaging==24.2
 pandas==2.2.3
-pillow==11.1.0
+pillow==11.2.1
 protobuf==5.29.4
 pycparser==2.22
 Pygments==2.19.1
@@ -39,7 +39,7 @@ tensorboard==2.19.0
 tensorboard-data-server==0.7.2
 tensorflow==2.19.0
 termcolor==3.0.1
-typing_extensions==4.13.1
+typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.3.0
 Werkzeug==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@ asgiref==3.7.2
 certifi==2025.1.31
 charset-normalizer==3.4.1
 colorama==0.4.6
-coverage==7.6.12
-Django==4.2.11
+coverage==7.8.0
+Django==4.2.20
 djangorestframework==3.15.2
 googlemaps==4.10.0
 idna==3.10
 iniconfig==2.0.0
 packaging==24.2
-pillow==11.1.0
+pillow==11.2.1
 pluggy==1.5.0
 pytest==8.3.5
 pytz==2024.1


### PR DESCRIPTION
* pillow 11.1.0 > 11.2.1
* typing_extensions 4.13.1 > 4.13.2
* coverage 7.6.12 > 7.8.0
* Django 4.2.11 > 4.2.20

DependaBot created a PR for  protobuf, but newer versions are incompatible