### PR TITLE
CI/CD Fixes

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,16 @@ jobs:
         python-version: [3.12]
 
     steps:
+      - name: Check if building identifier is necessary
+        id: changed-files
+        run: |
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^identify/'; then
+            echo "identify_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "identify_changed=false" >> $GITHUB_OUTPUT
+          fi
+      
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -51,11 +61,15 @@ jobs:
           docker push ghcr.io/uccs-sp25-cs4300-cs5300-1/leafquest:latest
 
       - name: Build Identifier
+        if: contains(github.event.head_commit.message, '[build-identify]') || 
+            steps.changed-files.outputs.identify_changed == 'true'
         run: |
           cd identify
           docker build -t ghcr.io/uccs-sp25-cs4300-cs5300-1/leafquest-identify:latest .
 
       - name: Push Identifier
+        if: contains(github.event.head_commit.message, '[build-identify]') || 
+            steps.changed-files.outputs.identify_changed == 'true'
         run: |
           docker push ghcr.io/uccs-sp25-cs4300-cs5300-1/leafquest-identify:latest
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -41,11 +41,6 @@ jobs:
           path: |
             feedback.md
 
-      - name: Fix OpenAI silliness
-        run: |
-          sed -i 's/```markdown//' feedback.md
-          sed -i '${s/```$//}' feedback.md
-
       - name: Comment Feedback on Pull Request
         uses: thollander/actions-comment-pull-request@v3.0.1
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sed -i '1i ```' pylint-report.txt
           sed -i '$a ```' pylint-report.txt
-          cat pylint-report
+          cat pylint-report.txt
 
       - name: Upload linter results
         if: always()

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,8 +37,13 @@ jobs:
         id: pylint
         run: |
           python -m pylint --recursive=y --output=pylint-report.txt LeafQuest/
+
+      - name: Always post-process report
+        if: always()
+        run: |
           sed -i '1i ```' pylint-report.txt
           sed -i '$a ```' pylint-report.txt
+          cat pylint-report
 
       - name: Upload linter results
         if: always()

--- a/ai-code-review.py
+++ b/ai-code-review.py
@@ -14,7 +14,7 @@ chat_completion = client.chat.completions.create(
         {"role": "system", "content": "You are an expert software engineer performing a code review on a Django project. Provide concise, actionable feedback."},
         {"role": "user", "content": f"Provide concise, actionable feedback in Markdown format, paying special attention to Django convention, security, and code efficiency, and in each case mentioning the file name and line number for the suggestion. Here's the pull request diff:\n{diff}"}
     ],
-    model="4o"
+    model="gpt-4o"
 )
 
 feedback = chat_completion.choices[0].message.content

--- a/ai-code-review.py
+++ b/ai-code-review.py
@@ -11,10 +11,10 @@ client = OpenAI(
 )
 chat_completion = client.chat.completions.create(
     messages=[
-        {"role": "system","content": "You are an expert software engineer performing a code review on a Django project. Provide concise, actionable feedback."},
+        {"role": "system", "content": "You are an expert software engineer performing a code review on a Django project. Provide concise, actionable feedback."},
         {"role": "user", "content": f"Provide concise, actionable feedback in Markdown format, paying special attention to Django convention, security, and code efficiency, and in each case mentioning the file name and line number for the suggestion. Here's the pull request diff:\n{diff}"}
     ],
-    model="o3-mini"
+    model="4o"
 )
 
 feedback = chat_completion.choices[0].message.content

--- a/ai-code-review.py
+++ b/ai-code-review.py
@@ -1,3 +1,4 @@
+import openai
 from openai import OpenAI
 import os
 
@@ -9,16 +10,34 @@ with open("diff.txt", "r") as file:
 client = OpenAI(
     api_key=os.getenv("OPENAI_API_KEY"),
 )
-chat_completion = client.chat.completions.create(
-    messages=[
-        {"role": "system", "content": "You are an expert software engineer performing a code review on a Django project. Provide concise, actionable feedback."},
-        {"role": "user", "content": f"Provide concise, actionable feedback in Markdown format, paying special attention to Django convention, security, and code efficiency, and in each case mentioning the file name and line number for the suggestion. Here's the pull request diff:\n{diff}"}
-    ],
-    model="gpt-4o"
-)
 
-feedback = chat_completion.choices[0].message.content
-print(feedback)
+try:
+    chat_completion = client.chat.completions.create(
+        messages=[
+            {"role": "system", "content": "You are an expert software engineer performing a code review on a Django project. Provide concise, actionable feedback."},
+            {"role": "user", "content": f"Provide concise, actionable feedback in Markdown format, paying special attention to Django convention, security, and code efficiency, and in each case mentioning the file name and line number for the suggestion. Here's the pull request diff:\n{diff}"}
+        ],
+        model="gpt-4o"
+    )
+
+    feedback = chat_completion.choices[0].message.content
+    print(feedback)
+
+except openai.RateLimitError:
+    print("Quota Exceeded")
+    feedback = "***Quota Exceeded***\nNo AI review available."
+
+# Remove the leading code fence if present
+if feedback.startswith("```markdown"):
+    feedback = feedback[len("```markdown"):]
+elif feedback.startswith("```"):
+    feedback = feedback[len("```"):]
+
+# Remove the trailing code fence if present
+feedback_stripped = feedback.rstrip()
+if feedback_stripped.endswith("```"):
+    feedback = feedback[:len(feedback) - 3]
+
 
 with open("feedback.md", "w") as file:
     file.write(f"## AI Code Review Feedback\n{feedback}")


### PR DESCRIPTION
- Linter results are available in the Always post-process report step
- leafquest-identify image building should now be skipped if no relevant files were changed (huge deployment speedup, tensorflow is a massive library)